### PR TITLE
Quickstart fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ embed-proplet/bootloader
 embed-proplet/modules
 embed-proplet/tools
 embed-proplet/zephyr
+
+.proplet_locks

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(SERVICES):
 	$(call compile_service,$(@))
 
 $(RUST_SERVICES):
-	cd proplet && cargo build --release
+	cd proplet && cargo build --release && cp target/release/proplet ../$(BUILD_DIR)/proplet
 
 $(DOCKERS):
 	$(call make_docker,$(@),$(GOARCH))

--- a/manager/service.go
+++ b/manager/service.go
@@ -356,6 +356,11 @@ func (svc *service) handle(ctx context.Context) func(topic string, msg map[strin
 				return err
 			}
 			svc.logger.InfoContext(ctx, "successfully created proplet")
+		case svc.baseTopic + "/control/proplet/destroy":
+			if err := svc.destroyPropletHandler(ctx, msg); err != nil {
+				return err
+			}
+			svc.logger.InfoContext(ctx, "successfully destroyed proplet")
 		case svc.baseTopic + "/control/proplet/alive":
 			return svc.updateLivenessHandler(ctx, msg)
 		case svc.baseTopic + "/control/proplet/results":
@@ -384,6 +389,21 @@ func (svc *service) createPropletHandler(ctx context.Context, msg map[string]any
 		Name: namegen.Generate(),
 	}
 	if err := svc.propletsDB.Create(ctx, p.ID, p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (svc *service) destroyPropletHandler(ctx context.Context, msg map[string]any) error {
+	propletID, ok := msg["proplet_id"].(string)
+	if !ok {
+		return errors.New("invalid proplet_id")
+	}
+	if propletID == "" {
+		return errors.New("proplet id is empty")
+	}
+	if err := svc.propletsDB.Delete(ctx, propletID); err != nil {
 		return err
 	}
 

--- a/proplet/src/main.rs
+++ b/proplet/src/main.rs
@@ -109,12 +109,14 @@ async fn main() -> Result<()> {
 
         info!("Received shutdown signal, cleaning up...");
 
-        if let Err(e) = pubsub_clone.disconnect().await {
-            tracing::error!("Failed to disconnect gracefully: {}", e);
-        }
-
         if let Err(e) = service_clone.publish_goodbye().await {
             tracing::error!("Failed to publish goodbye message: {}", e);
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        if let Err(e) = pubsub_clone.disconnect().await {
+            tracing::error!("Failed to disconnect gracefully: {}", e);
         }
 
         info!("Graceful shutdown complete");

--- a/proplet/src/main.rs
+++ b/proplet/src/main.rs
@@ -113,6 +113,11 @@ async fn main() -> Result<()> {
             tracing::error!("Failed to publish goodbye message: {}", e);
         }
 
+        // Release config lock
+        if let Err(e) = PropletConfig::release_lock(&config.client_id) {
+            tracing::error!("Failed to release config lock: {}", e);
+        }
+
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
         if let Err(e) = pubsub_clone.disconnect().await {

--- a/proplet/src/main.rs
+++ b/proplet/src/main.rs
@@ -101,6 +101,7 @@ async fn main() -> Result<()> {
     #[cfg(not(feature = "tee"))]
     let service = Arc::new(PropletService::new(config.clone(), pubsub, runtime));
 
+    let service_clone = service.clone();
     let shutdown_handle = tokio::spawn(async move {
         tokio::signal::ctrl_c()
             .await
@@ -110,6 +111,10 @@ async fn main() -> Result<()> {
 
         if let Err(e) = pubsub_clone.disconnect().await {
             tracing::error!("Failed to disconnect gracefully: {}", e);
+        }
+
+        if let Err(e) = service_clone.publish_goodbye().await {
+            tracing::error!("Failed to publish goodbye message: {}", e);
         }
 
         info!("Graceful shutdown complete");

--- a/proplet/src/runtime/wasmtime_runtime.rs
+++ b/proplet/src/runtime/wasmtime_runtime.rs
@@ -64,7 +64,7 @@ impl Runtime for WasmtimeRuntime {
             .context("Failed to instantiate Wasmtime module")?;
 
         // Set epoch deadline for interruption (allow stop_app to terminate infinite loops)
-        store.set_epoch_deadline(1);
+        store.set_epoch_deadline(100);
 
         if config.daemon {
             info!("Running in daemon mode for task: {}", config.id);

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -229,6 +229,30 @@ impl PropletService {
         Ok(())
     }
 
+    pub async fn publish_goodbye(&self) -> Result<()> {
+        let goodbye = DiscoveryMessage {
+            proplet_id: self.config.client_id.clone(),
+            namespace: self
+                .config
+                .k8s_namespace
+                .clone()
+                .unwrap_or_else(|| "default".to_string()),
+        };
+
+        let topic = build_topic(
+            &self.config.domain_id,
+            &self.config.channel_id,
+            "control/proplet/destroy",
+        );
+
+        self.pubsub
+            .publish(&topic, &goodbye, self.config.qos())
+            .await?;
+        info!("Published goodbye message");
+
+        Ok(())
+    }
+
     async fn start_liveliness_updates(&self) {
         let mut interval = tokio::time::interval(self.config.liveliness_interval());
 

--- a/proplet/src/service.rs
+++ b/proplet/src/service.rs
@@ -184,14 +184,14 @@ impl PropletService {
         let start_topic = build_topic(
             &self.config.domain_id,
             &self.config.channel_id,
-            "control/manager/start",
+            &format!("control/proplet/{}/start", self.config.client_id),
         );
         self.pubsub.subscribe(&start_topic, qos).await?;
 
         let stop_topic = build_topic(
             &self.config.domain_id,
             &self.config.channel_id,
-            "control/manager/stop",
+            &format!("control/proplet/{}/stop", self.config.client_id),
         );
         self.pubsub.subscribe(&stop_topic, qos).await?;
 
@@ -354,9 +354,15 @@ impl PropletService {
             debug!("Raw message payload: {}", payload_str);
         }
 
-        if msg.topic.contains("control/manager/start") {
+        if msg
+            .topic
+            .contains(&format!("control/proplet/{}/start", self.config.client_id))
+        {
             self.handle_start_command(msg).await
-        } else if msg.topic.contains("control/manager/stop") {
+        } else if msg
+            .topic
+            .contains(&format!("control/proplet/{}/stop", self.config.client_id))
+        {
             self.handle_stop_command(msg).await
         } else if msg.topic.contains("registry/server") {
             self.handle_chunk(msg).await


### PR DESCRIPTION
* Tweaked the Makefile to properly locate the built proplet binary.
* Added goodbye message handling to enable proplet unregistration from the manager.
* Added automatic configuration selection and a lock file to enable the use of multiple proplets.
* Increased the epoch deadline for the Wasmtime runtime to prevent premature task interrupts.
* Added proplet-specific channels to enable unicast task execution instead of global broadcasting.